### PR TITLE
pull out slf4j-log4j12

### DIFF
--- a/bulldog-core/pom.xml
+++ b/bulldog-core/pom.xml
@@ -25,9 +25,5 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/bulldog-linux/pom.xml
+++ b/bulldog-linux/pom.xml
@@ -19,5 +19,10 @@
          <artifactId>bulldog-core</artifactId>
          <version>${project.version}</version>
       </dependency>
+          <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
    </dependencies>
 </project>

--- a/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/sysinfo/CpuInfo.java
+++ b/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/sysinfo/CpuInfo.java
@@ -1,49 +1,50 @@
 package io.silverspoon.bulldog.linux.sysinfo;
 
-import org.apache.log4j.Logger;
-
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CpuInfo {
 
-   private static Logger LOG = Logger.getLogger(CpuInfo.class);
+	private final static Logger logger = LoggerFactory.getLogger(CpuInfo.class);
 
-   private static final String CPU_REVISION = "CPU revision";
-   private static final String HW = "Hardware";
+	private static final String CPU_REVISION = "CPU revision";
+	private static final String HW = "Hardware";
 
-   private static HashMap<String, String> properties = new HashMap<String, String>();
+	private static HashMap<String, String> properties = new HashMap<String, String>();
 
-   static {
-      String cpuInfo = readFile("/proc/cpuinfo");
-      String[] infos = cpuInfo.split("\n");
-      for (String info : infos) {
-         String[] tokens = info.split(":");
-         if (tokens.length >= 2) {
-            properties.put(tokens[0].trim(), tokens[1].trim());
-         }
-      }
-   }
+	static {
+		String cpuInfo = readFile("/proc/cpuinfo");
+		String[] infos = cpuInfo.split("\n");
+		for (String info : infos) {
+			String[] tokens = info.split(":");
+			if (tokens.length >= 2) {
+				properties.put(tokens[0].trim(), tokens[1].trim());
+			}
+		}
+	}
 
-   public static String getCPURevision() {
-      return properties.get(CPU_REVISION);
-   }
+	public static String getCPURevision() {
+		return properties.get(CPU_REVISION);
+	}
 
-   public static String getHardware() {
-      return properties.get(HW);
-   }
+	public static String getHardware() {
+		return properties.get(HW);
+	}
 
-   private static String readFile(String path) {
-      try {
-         byte[] encoded = Files.readAllBytes(Paths.get(path));
-         return new String(encoded, Charset.defaultCharset());
-      } catch (IOException e) {
-         LOG.error("Cannot read file " + path, e);
-      }
+	private static String readFile(String path) {
+		try {
+			byte[] encoded = Files.readAllBytes(Paths.get(path));
+			return new String(encoded, Charset.defaultCharset());
+		} catch (IOException e) {
+			logger.error("Cannot read file " + path, e);
+		}
 
-      return "";
-   }
+		return "";
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
-  <description>Java GPIO Library for BeagleBonBlack, Raspberry Pi and CubieBoard.</description>
+  <description>Java GPIO Library for BeagleBoneBlack, Raspberry Pi and CubieBoard.</description>
   <url>http://silverspoon.io</url>
   <licenses>
     <license>
@@ -94,11 +94,6 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${version.slf4j}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
         <version>${version.slf4j}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
The slf4j implementation should not be in the library, but rather in the client code, such as in `bulldog-examples`. In the client app's pom you can put 

    <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-simple</artifactId>
        <version>1.7.12</version>
    </dependency>

or use log4j or whatever.

