### PR TITLE
Added checks to memory mapping (fixes #49)

### DIFF
--- a/bulldog-linux-native/src/main/c/linux/jni/io_silverspoon_bulldog_linux_jni_NativeMmap.c
+++ b/bulldog-linux-native/src/main/c/linux/jni/io_silverspoon_bulldog_linux_jni_NativeMmap.c
@@ -11,7 +11,14 @@
 JNIEXPORT jlong JNICALL Java_io_silverspoon_bulldog_linux_jni_NativeMmap_createMap
   (JNIEnv * env, jobject clazz, jlong address, jlong length, jint prot, jint flags, jint fileDescriptor, jlong offset) {
 	int * addrPointer = (int*)(intptr_t)address;
-	return (jlong)(intptr_t)mmap(addrPointer, length, prot, flags, fileDescriptor, offset);
+	void *retval = NULL;
+
+	retval = mmap(addrPointer, length, prot, flags, fileDescriptor, offset);
+	if (retval == MAP_FAILED) {
+	   perror("mmap");
+	   return (jlong)(intptr_t)0x0;
+	}
+	return (jlong)(intptr_t)retval;
 }
 
 /*

--- a/bulldog-linux-native/src/main/c/linux/jni/io_silverspoon_bulldog_linux_jni_NativeTools.c
+++ b/bulldog-linux-native/src/main/c/linux/jni/io_silverspoon_bulldog_linux_jni_NativeTools.c
@@ -47,9 +47,15 @@ JNIEXPORT jobject JNICALL Java_io_silverspoon_bulldog_linux_jni_NativeTools_getJ
 JNIEXPORT jint JNICALL Java_io_silverspoon_bulldog_linux_jni_NativeTools_open
 (JNIEnv * env, jclass clazz, jstring path, jint flags) {
 	char fileName[256];
-	int len = (*env)->GetStringLength(env, path);
+	int len = (*env)->GetStringLength(env, path), fd = 0;
+
 	(*env)->GetStringUTFRegion(env, path, 0, len, fileName);
-	return open(fileName, flags);
+	fd = open(fileName, flags);
+	if (fd == -1) {
+	   perror(fileName);
+	}
+
+	return fd;
 
 }
 

--- a/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/io/mmap/MemoryMap.java
+++ b/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/io/mmap/MemoryMap.java
@@ -2,6 +2,7 @@ package io.silverspoon.bulldog.linux.io.mmap;
 
 import io.silverspoon.bulldog.linux.jni.NativeMmap;
 import io.silverspoon.bulldog.linux.jni.NativeTools;
+import io.silverspoon.bulldog.linux.util.MMapFailedException;
 
 public class MemoryMap {
 
@@ -14,7 +15,13 @@ public class MemoryMap {
 
    public MemoryMap(String filename, long offset, long size, long address) {
       fileDescriptor = NativeTools.open(filename, NativeTools.OPEN_READ_WRITE);
+      if (fileDescriptor == -1) {
+         throw new MMapFailedException("Unable to open file " + filename);
+      }
       mmapPointer = NativeMmap.createMap(0, size, NativeMmap.READ | NativeMmap.WRITE, NativeMmap.SHARED, fileDescriptor, offset);
+      if (mmapPointer == 0x0) {
+         throw new MMapFailedException("Unable to map memory");
+      }
    }
 
    public void closeMap() {

--- a/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/util/MMapFailedException.java
+++ b/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/util/MMapFailedException.java
@@ -1,6 +1,8 @@
 package io.silverspoon.bulldog.linux.util;
 
-
+/**
+ * Thrown when MMap in native parts fails.
+ */
 public class MMapFailedException extends RuntimeException {
 
    public MMapFailedException() {

--- a/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/util/MMapFailedException.java
+++ b/bulldog-linux/src/main/java/io/silverspoon/bulldog/linux/util/MMapFailedException.java
@@ -1,0 +1,21 @@
+package io.silverspoon.bulldog.linux.util;
+
+
+public class MMapFailedException extends RuntimeException {
+
+   public MMapFailedException() {
+      super();
+   }
+
+   public MMapFailedException(String message, Throwable cause) {
+      super(message, cause);
+   }
+
+   public MMapFailedException(Throwable cause) {
+      super(cause);
+   }
+
+   public MMapFailedException(String message) {
+      super(message);
+   }
+}


### PR DESCRIPTION
This fix prevents JVM from crashing. When opening file or mapping memory
fails RuntimeException is thrown.